### PR TITLE
Thanos mode

### DIFF
--- a/components/TeamList/TeamList.jsx
+++ b/components/TeamList/TeamList.jsx
@@ -21,8 +21,13 @@ const StyledUl = styled.ul`
 
 `
 
-const nameLogic = ({ timing, teamMembersGone, teamMembersToGo, position, member }) => {
-  if (!timing) return (<StyledLi key={member}><Name name={`${member}`}/></StyledLi>)
+const nameLogic = ({ timing, isReducedTeam, regularDrop, teamMembersGone, teamMembersToGo, position, member }) => {
+  if (!timing) {
+    if (isReducedTeam || regularDrop) {
+      if (teamMembersGone.includes(member)) return (<StyledLi key={member}><Name name={`✅ ${member}`}/></StyledLi>)
+    }
+    return (<StyledLi key={member}><Name name={`${member}`}/></StyledLi>)
+  }
 
   if (teamMembersGone.includes(member)) return (<StyledLi key={member}><Name name={`✅ ${member}`}/></StyledLi>)
 
@@ -30,10 +35,12 @@ const nameLogic = ({ timing, teamMembersGone, teamMembersToGo, position, member 
   return (<StyledLi key={member}><Name name={`${member}`}/></StyledLi>)
 }
 
-const TeamList = ({ timing, team, teamMembersGone, teamMembersToGo, position }) => (
+const TeamList = ({ timing, isReducedTeam, regularDrop, team, teamMembersGone, teamMembersToGo, position }) => (
   <StyledUl>
     {team.map(member => nameLogic({
       timing,
+      isReducedTeam,
+      regularDrop,
       teamMembersGone,
       teamMembersToGo,
       position,

--- a/components/TeamList/TeamList.jsx
+++ b/components/TeamList/TeamList.jsx
@@ -21,12 +21,9 @@ const StyledUl = styled.ul`
 
 `
 
-const nameLogic = ({ timing, isReducedTeam, regularDrop, teamMembersGone, teamMembersToGo, position, member }) => {
+const nameLogic = ({ timing, isReducedTeam, teamMembersGone, teamMembersToGo, position, member }) => {
   if (!timing) {
-    if (isReducedTeam || regularDrop) {
-      if (teamMembersGone.includes(member)) return (<StyledLi key={member}><Name name={`✅ ${member}`}/></StyledLi>)
-    }
-    return (<StyledLi key={member}><Name name={`${member}`}/></StyledLi>)
+    return teamMembersGone.includes(member) ? <StyledLi key={member}><Name name={`✅ ${member}`}/></StyledLi> : <StyledLi key={member}><Name name={`${member}`}/></StyledLi>
   }
 
   if (teamMembersGone.includes(member)) return (<StyledLi key={member}><Name name={`✅ ${member}`}/></StyledLi>)
@@ -35,12 +32,11 @@ const nameLogic = ({ timing, isReducedTeam, regularDrop, teamMembersGone, teamMe
   return (<StyledLi key={member}><Name name={`${member}`}/></StyledLi>)
 }
 
-const TeamList = ({ timing, isReducedTeam, regularDrop, team, teamMembersGone, teamMembersToGo, position }) => (
+const TeamList = ({ timing, isReducedTeam, team, teamMembersGone, teamMembersToGo, position }) => (
   <StyledUl>
     {team.map(member => nameLogic({
       timing,
       isReducedTeam,
-      regularDrop,
       teamMembersGone,
       teamMembersToGo,
       position,

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "dev": "next",
-    "build": "next build",
+    "dev": "rm -rf .next && next",
+    "build": "rm -rf .next && next build",
     "start": "next start"
   },
   "dependencies": {

--- a/pages/webcore-pres.jsx
+++ b/pages/webcore-pres.jsx
@@ -126,21 +126,21 @@ export default () => {
     startTiming(false)
   }
 
-  const dropPersonOnDay = (person, day) => {
-    const dayNumber = {
-      monday: 1,
-      tuesday: 2,
-      wednesday: 3,
-      thursday: 4,
-      friday: 5
+  const dropPersonOnDay = () => {
+    const outOfOfficeRota = {
+      1: ['Abigail'], // Monday
+      2: ['Pete'],
+      3: [],
+      4: [],
+      5: []
     }
 
-    if (new Date().getDay() === dayNumber[day.toLowerCase()]) {
-      dropTeamMembers([person])
-    }
+    const teamOutOfOffice = outOfOfficeRota[new Date().getDay()]
+    dropTeamMembers(teamOutOfOffice)
   }
+
   if (!regularDrop) {
-    dropPersonOnDay('Pete', 'tuesday')
+    dropPersonOnDay()
     setRegularDrop(true)
   }
 
@@ -201,6 +201,8 @@ export default () => {
 
       <TeamList
         timing={timing}
+        isReducedTeam={isReducedTeam}
+        regularDrop={regularDrop}
         team={team}
         teamMembersGone={teamState.teamMembersGone}
         teamMembersToGo={teamState.teamMembersToGo}

--- a/pages/webcore-pres.jsx
+++ b/pages/webcore-pres.jsx
@@ -132,7 +132,7 @@ export default () => {
   const dropPersonOnDay = () => {
     const outOfOfficeRota = {
       1: ['Abigail'], // Monday
-      2: ['Pete'],
+      2: [],
       3: [],
       4: [],
       5: []
@@ -186,15 +186,15 @@ export default () => {
 
   const thanosButton = (
     <Button onClick={() => reduceTeam(teamToDrop)}>
-      <ButtonText>{ 
-      `Thanos Mode (less than ${team.length - (teamToDrop.length + teamState.teamMembersGone.length)} on the call?)`
+      <ButtonText>{
+        `Thanos Mode (less than ${team.length - (teamToDrop.length + teamState.teamMembersGone.length)} on the call?)`
       }
       </ButtonText>
     </Button>
   )
 
   const resurrectButton = (
-    <Button onClick={() => expandTeam()}><ButtonText>Resurrect Mode</ButtonText></Button>
+    <Button onClick={() => expandTeam()}><ButtonText>Resurrect</ButtonText></Button>
   )
 
   return (

--- a/pages/webcore-pres.jsx
+++ b/pages/webcore-pres.jsx
@@ -52,6 +52,7 @@ const Button = styled.button`
   height: 3rem;
   border: 1px solid ${({ theme }) => theme.colors.border};
   outline: 0px;
+  margin: 5px;
 `
 
 const ButtonText = styled.p`
@@ -82,6 +83,8 @@ export default () => {
   const [teamState, setTeamState] = useState({ teamMembersToGo, teamMembersGone, position: randomNumber({ max: teamMembersToGo.length }) })
   const [totalTime, setTotalTime] = useState(0)
   const [timing, startTiming] = useState(false)
+  const [isReducedTeam, setReducedTeam] = useState(false)
+  const [regularDrop, setRegularDrop] = useState(false)
 
   const current = teamState.teamMembersToGo[teamState.position]
 
@@ -95,6 +98,50 @@ export default () => {
 
   const nextPerson = () => {
     setTeamState(movePerson({ teamState, position: teamState.position }))
+  }
+
+  const dropTeamMembers = (toDrop) => {
+    const teamToKeep = teamState.teamMembersToGo.filter(member => {
+      return !toDrop.includes(member)
+    })
+
+    setTeamState({ teamMembersToGo: teamToKeep, teamMembersGone: toDrop, position: randomNumber({ max: teamToKeep.length }) })
+  }
+
+  const reduceTeam = (toDrop) => {
+    dropTeamMembers(toDrop)
+    setReducedTeam(!isReducedTeam)
+  }
+
+  const expandTeam = () => {
+    resetTeam()
+    setReducedTeam(!isReducedTeam)
+  }
+
+  const resetTeam = () => {
+    setTeamState({ teamMembersToGo: [...team], teamMembersGone: [], position: randomNumber({ max: team.length }) })
+    setRegularDrop(false)
+    setReducedTeam(false)
+    setTotalTime(0)
+    startTiming(false)
+  }
+
+  const dropPersonOnDay = (person, day) => {
+    const dayNumber = {
+      monday: 1,
+      tuesday: 2,
+      wednesday: 3,
+      thursday: 4,
+      friday: 5
+    }
+
+    if (new Date().getDay() === dayNumber[day.toLowerCase()]) {
+      dropTeamMembers([person])
+    }
+  }
+  if (!regularDrop) {
+    dropPersonOnDay('Pete', 'tuesday')
+    setRegularDrop(true)
   }
 
   const averageTimePerPerson = teamState.teamMembersGone.length
@@ -126,6 +173,20 @@ export default () => {
       </Stack>
     </RightWrapper>
   )
+  const teamToDrop = [
+    'Edwina',
+    'Johnathan',
+    'Keith M',
+    'Mike'
+  ]
+
+  const thanosButton = (
+    <Button onClick={() => reduceTeam(teamToDrop)}><ButtonText>Thanos Mode</ButtonText></Button>
+  )
+
+  const resurrectButton = (
+    <Button onClick={() => expandTeam()}><ButtonText>Resurrect Mode</ButtonText></Button>
+  )
 
   return (
     <Stack>
@@ -134,7 +195,8 @@ export default () => {
       <>
         {!timing ? <Button onClick={() => startTiming(true)}><ButtonText>Start Standup</ButtonText></Button> : ' '}
         {timing && teamState.teamMembersToGo.length !== 0 ? <Button onClick={nextPerson}><ButtonText>Next Person</ButtonText></Button> : ' '}
-        {timing && teamState.teamMembersToGo.length === 0 ? <Button onClick={() => {}}><ButtonText>Reset Standup</ButtonText></Button> : ' '}
+        {timing && teamState.teamMembersToGo.length === 0 ? <Button onClick={() => resetTeam()}><ButtonText>Reset Standup</ButtonText></Button> : ' '}
+        {isReducedTeam ? resurrectButton : thanosButton }
       </>
 
       <TeamList
@@ -144,8 +206,6 @@ export default () => {
         teamMembersToGo={teamState.teamMembersToGo}
         position={teamState.position}
       />
-
-      <iframe src="https://jira.dev.bbc.co.uk/secure/RapidBoard.jspa?rapidView=10532&view=detail" width="100%" height="600px"/>
 
     </Stack>
   )

--- a/pages/webcore-pres.jsx
+++ b/pages/webcore-pres.jsx
@@ -11,7 +11,6 @@ import Paragraph from 'components/Paragraph'
 const team = [
   'Abigail',
   'Ben (8am-4pm)',
-  'Callum',
   'Carlos',
   'Dave',
   'Dom \'not\' the legend',

--- a/pages/webcore-pres.jsx
+++ b/pages/webcore-pres.jsx
@@ -101,11 +101,13 @@ export default () => {
   }
 
   const dropTeamMembers = (toDrop) => {
+    const allMembersGone = [...toDrop, ...teamState.teamMembersGone]
+    console.log(allMembersGone)
     const teamToKeep = teamState.teamMembersToGo.filter(member => {
-      return !toDrop.includes(member)
+      return !allMembersGone.includes(member)
     })
-
-    setTeamState({ teamMembersToGo: teamToKeep, teamMembersGone: toDrop, position: randomNumber({ max: teamToKeep.length }) })
+    console.log(teamToKeep)
+    setTeamState({ teamMembersToGo: teamToKeep, teamMembersGone: allMembersGone, position: randomNumber({ max: teamToKeep.length }) })
   }
 
   const reduceTeam = (toDrop) => {

--- a/pages/webcore-pres.jsx
+++ b/pages/webcore-pres.jsx
@@ -12,6 +12,7 @@ const team = [
   'Abigail',
   'Ben (8am-4pm)',
   'Carlos',
+  'Callum',
   'Dave',
   'Dom \'not\' the legend',
   'Edwina',
@@ -176,6 +177,7 @@ export default () => {
     </RightWrapper>
   )
   const teamToDrop = [
+    'Callum',
     'Edwina',
     'Johnathan',
     'Keith M',
@@ -183,7 +185,12 @@ export default () => {
   ]
 
   const thanosButton = (
-    <Button onClick={() => reduceTeam(teamToDrop)}><ButtonText>Thanos Mode</ButtonText></Button>
+    <Button onClick={() => reduceTeam(teamToDrop)}>
+      <ButtonText>{ 
+      `Thanos Mode (less than ${team.length - (teamToDrop.length + teamState.teamMembersGone.length)} on the call?)`
+      }
+      </ButtonText>
+    </Button>
   )
 
   const resurrectButton = (

--- a/pages/webcore-pres.jsx
+++ b/pages/webcore-pres.jsx
@@ -84,7 +84,7 @@ export default () => {
   const [teamState, setTeamState] = useState({ teamMembersToGo, teamMembersGone, position: randomNumber({ max: teamMembersToGo.length }) })
   const [totalTime, setTotalTime] = useState(0)
   const [timing, startTiming] = useState(false)
-  const [isReducedTeam, setReducedTeam] = useState(false)
+  const [onlyPresLayerTeam, setOnlyPresLayerTeam] = useState(false)
   const [regularDrop, setRegularDrop] = useState(false)
 
   const current = teamState.teamMembersToGo[teamState.position]
@@ -102,34 +102,34 @@ export default () => {
   }
 
   const dropTeamMembers = (toDrop) => {
-    const allMembersGone = [...toDrop, ...teamState.teamMembersGone]
-    console.log(allMembersGone)
-    const teamToKeep = teamState.teamMembersToGo.filter(member => {
-      return !allMembersGone.includes(member)
+    const teamMembersGone = [...toDrop, ...teamState.teamMembersGone]
+
+    const teamMembersToGo = teamState.teamMembersToGo.filter(member => {
+      return !teamMembersGone.includes(member)
     })
-    console.log(teamToKeep)
-    setTeamState({ teamMembersToGo: teamToKeep, teamMembersGone: allMembersGone, position: randomNumber({ max: teamToKeep.length }) })
-  }
 
-  const reduceTeam = (toDrop) => {
-    dropTeamMembers(toDrop)
-    setReducedTeam(!isReducedTeam)
-  }
-
-  const expandTeam = () => {
-    resetTeam()
-    setReducedTeam(!isReducedTeam)
+    setTeamState({ teamMembersToGo, teamMembersGone, position: randomNumber({ max: teamMembersToGo.length }) })
   }
 
   const resetTeam = () => {
     setTeamState({ teamMembersToGo: [...team], teamMembersGone: [], position: randomNumber({ max: team.length }) })
     setRegularDrop(false)
-    setReducedTeam(false)
+    setOnlyPresLayerTeam(false)
     setTotalTime(0)
     startTiming(false)
   }
 
-  const dropPersonOnDay = () => {
+  const reduceTeam = (toDrop) => {
+    dropTeamMembers(toDrop)
+    setOnlyPresLayerTeam(true)
+  }
+
+  const expandTeam = () => {
+    resetTeam()
+    setOnlyPresLayerTeam(false)
+  }
+
+  const regularOutOfOffice = () => {
     const outOfOfficeRota = {
       1: ['Abigail'], // Monday
       2: [],
@@ -138,12 +138,12 @@ export default () => {
       5: []
     }
 
-    const teamOutOfOffice = outOfOfficeRota[new Date().getDay()]
-    dropTeamMembers(teamOutOfOffice)
+    const outOfOffice = outOfOfficeRota[new Date().getDay()]
+    dropTeamMembers(outOfOffice)
   }
 
   if (!regularDrop) {
-    dropPersonOnDay()
+    regularOutOfOffice()
     setRegularDrop(true)
   }
 
@@ -176,6 +176,7 @@ export default () => {
       </Stack>
     </RightWrapper>
   )
+
   const teamToDrop = [
     'Callum',
     'Edwina',
@@ -187,7 +188,7 @@ export default () => {
   const thanosButton = (
     <Button onClick={() => reduceTeam(teamToDrop)}>
       <ButtonText>{
-        `Thanos Mode (less than ${team.length - (teamToDrop.length + teamState.teamMembersGone.length)} on the call?)`
+        `Thanos Mode (less than ${team.length + 1 - (teamToDrop.length + teamState.teamMembersGone.length)} on the call?)`
       }
       </ButtonText>
     </Button>
@@ -205,13 +206,12 @@ export default () => {
         {!timing ? <Button onClick={() => startTiming(true)}><ButtonText>Start Standup</ButtonText></Button> : ' '}
         {timing && teamState.teamMembersToGo.length !== 0 ? <Button onClick={nextPerson}><ButtonText>Next Person</ButtonText></Button> : ' '}
         {timing && teamState.teamMembersToGo.length === 0 ? <Button onClick={() => resetTeam()}><ButtonText>Reset Standup</ButtonText></Button> : ' '}
-        {isReducedTeam ? resurrectButton : thanosButton }
+        {onlyPresLayerTeam ? resurrectButton : thanosButton }
       </>
 
       <TeamList
         timing={timing}
-        isReducedTeam={isReducedTeam}
-        regularDrop={regularDrop}
+        isReducedTeam={onlyPresLayerTeam || regularDrop}
         team={team}
         teamMembersGone={teamState.teamMembersGone}
         teamMembersToGo={teamState.teamMembersToGo}


### PR DESCRIPTION
## Whats been added 
1. Thanos mode - Button to drop a list of hardcoded people (teamToDrop) which is based on who normally does not attend standup. A suggestion on when to use Thanos is made. Once clicked button changes to Resurrection

2. Resurrection - Undoes Thanos and restarts standup to original state. Once clicked changes back to Thanos button.

3. reset standup - Resets the board to the original state. Used for Resurrection and when standup is complete.

4. Out of Office - Automatically drops a hardcoded list of people (outOfOfficeRota) based on the day of the week. This is included in the original state of the board i.e reset standup does not affect the effect of out of office.

## Whats been removed 
1. iframe of jira board as it was erroring and took awhile to load.

